### PR TITLE
Add two-way binding support.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,13 +36,13 @@ function Counter() {
 
 // render
 ReactDOM.render(
-    [h(Counter), h(Counter)], // render two counters to flex the globalness
+    [<Counter />, <Counter />], // render two counters to flex the globalness
     document.querySelector("main")
 );
 
 // fun fact, you can get a read-writable object of the state with useSenko.current()
 // probably dont use this for production though lol 
-console.log(useSenko.current())
+console.log(useSenko.current());
 ```
 
 ## go czech it out ;)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import createObservable from "./observable";
 
 export * from "./observable";
 export * from "./senko";
+export * from "./model";
+
 export { createObservable };
 
 export default senko;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,0 +1,18 @@
+import React from "react";
+
+export interface IModel<Value> {
+    value: Value;
+    onInput: React.FormEventHandler<HTMLInputElement>;
+}
+
+export default function model<Store>(
+    store: Store,
+    prop: keyof Store
+): IModel<Store[keyof Store]> {
+    return {
+        value: store[prop],
+        onInput: ({ target }) =>
+            (store[prop] = ((target as HTMLInputElement)
+                .value as unknown) as Store[keyof Store]),
+    };
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -3,16 +3,26 @@ import React from "react";
 export interface IModel<Value> {
     value: Value;
     onInput: React.FormEventHandler<HTMLInputElement>;
+    onChange: React.FormEventHandler<HTMLInputElement>;
 }
 
 export default function model<Store>(
     store: Store,
     prop: keyof Store
-): IModel<Store[keyof Store]> {
+): IModel<Store[keyof Store]> { 
+    const handler: React.FormEventHandler<HTMLInputElement> = ({ target }) => {
+        let inputProp: "value" | "checked" = "value";
+
+        if ((target as HTMLInputElement).type = "checkbox") {
+            inputProp = "checked";
+        }
+
+        (store[prop] = ((target as HTMLInputElement)[inputProp] as unknown) as Store[keyof Store])
+    }
+
     return {
         value: store[prop],
-        onInput: ({ target }) =>
-            (store[prop] = ((target as HTMLInputElement)
-                .value as unknown) as Store[keyof Store]),
+        onInput: handler,
+        onChange: handler
     };
 }

--- a/src/senko.ts
+++ b/src/senko.ts
@@ -1,38 +1,48 @@
 import { useState } from "react";
+import model, { IModel } from "./model";
 import createObservable from "./observable";
+
+export type Senko<Store> = Store & {
+    model: Record<keyof Store, <Value>() => ReturnType<typeof model>>
+}
 
 export type SenkoState<Value> = [Value, (val: Value) => void];
 
-export default function senko<StoreType>(initial: StoreType) {
+export default function senko<Store>(initial: Store) {
     const observable = createObservable(initial);
 
-    const useSpecificState = <ValueType = StoreType[keyof StoreType]>(
-        prop: keyof StoreType
-    ): SenkoState<ValueType> => {
-        const [value, setValue] = useState<ValueType>(
-            (observable.data[prop] as unknown) as ValueType
+    const useSpecificState = <Value = Store[keyof Store]>(
+        prop: keyof Store
+    ): SenkoState<Value> => {
+        const [value, setValue] = useState<Value>(
+            (observable.data[prop] as unknown) as Value
         );
 
-        observable.attach<ValueType>(prop, setValue);
+        observable.attach<Value>(prop, setValue);
 
-        const setter = (newValue: ValueType) => {
+        const setter = (newValue: Value) => {
             observable.data[
                 prop
-            ] = (newValue as unknown) as StoreType[keyof StoreType];
+            ] = (newValue as unknown) as Store[keyof Store];
         };
 
         return [value, setter];
     };
 
-    const useSenko = () => {
-        const stateObject: StoreType = Object.create(null);
+    const useSenko = (): Senko<Store> => {
+        const stateObject: Senko<Store> = Object.create(null);
+        stateObject.model = Object.create(null);
 
-        for (const prop of Object.keys(initial) as (keyof StoreType)[]) {
+        for (const prop of Object.keys(initial) as (keyof Store)[]) {
             const [val, setVal] = useSpecificState(prop);
 
             Object.defineProperty(stateObject, prop, {
                 get: () => val,
                 set: setVal,
+            });
+
+            Object.defineProperty(stateObject.model, prop, {
+                get: () => model(stateObject, prop),
             });
         }
 


### PR DESCRIPTION
Weird `v-model` inspired two-way binding for inputs and checkboxes

Syntax:

```js

const state = useSenko();

// state has a name property
// use state.model.name

<h1>The name is: {state.name}</h1>
<input {...state.model.name} />
```